### PR TITLE
Fix bug in keypaths function

### DIFF
--- a/tag_bot/utils.py
+++ b/tag_bot/utils.py
@@ -19,10 +19,16 @@ def keypaths(nested_dict: Mapping) -> Generator:
         if isinstance(value, Mapping):
             for subkey, subvalue in keypaths(value):
                 yield [key] + subkey, subvalue
+
         elif isinstance(value, list):
             for i in range(len(value)):
-                for subkey, subvalue in keypaths(value[i]):
-                    yield [f"{key}[{str(i)}]"] + subkey, subvalue
+                if isinstance(value[i], dict):
+                    for subkey, subvalue in keypaths(value[i]):
+                        yield [f"{key}[{str(i)}]"] + subkey, subvalue
+
+                elif isinstance(value[i], str):
+                    yield [f"{key}[{str(i)}]"], value[i]
+
         else:
             yield [key], value
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -27,6 +27,11 @@ def test_create_reverse_lookup_dict_simple():
 def test_create_reverse_lookup_dict_complex():
     test_dict = {
         "jupyterhub": {
+            "hub": {
+                "config": {
+                    "Authenticator": {"allowed_users": ["userA", "userB", "userC"]}
+                }
+            },
             "singleuser": {
                 "image": {"name": "image_name", "tag": "image_tag"},
                 "profileList": [
@@ -34,7 +39,7 @@ def test_create_reverse_lookup_dict_complex():
                     {"kubespawner_override": {"image": "image_name:image_tag"}},
                     {"kubespawner_override": {"image": "image_name2:image_tag2"}},
                 ],
-            }
+            },
         }
     }
 
@@ -56,6 +61,9 @@ def test_create_reverse_lookup_dict_complex():
             "image",
         ],
         "image_tag": ["jupyterhub", "singleuser", "image", "tag"],
+        "userA": ["jupyterhub", "hub", "config", "Authenticator", "allowed_users[0]"],
+        "userB": ["jupyterhub", "hub", "config", "Authenticator", "allowed_users[1]"],
+        "userC": ["jupyterhub", "hub", "config", "Authenticator", "allowed_users[2]"],
     }
 
     result = create_reverse_lookup_dict(test_dict)


### PR DESCRIPTION
Allow `keypaths` to handle lists of strings, not just lists of dicts. Also extend tests to catch this case.