### PR TITLE
Update docker CI on only build/push latest tag

### DIFF
--- a/.github/workflows/docker-build-push.yaml
+++ b/.github/workflows/docker-build-push.yaml
@@ -4,17 +4,26 @@ on:
   push:
     branches:
       - "main"
-    tags:
-      - "v*.*.*"
   pull_request:
     branches:
       - "main"
 
 jobs:
   docker-build-push:
-    uses: sgibson91/.github/.github/workflows/docker-build.yaml@main
-    with:
-      image_name: sgibson91/bump-jhub-image-action
-    secrets:
-      docker_username: ${{ secrets.DOCKER_USERNAME }}
-      docker_password: ${{ secrets.DOCKER_PASSWORD }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2.4.0
+
+      - name: Login to Docker Hub
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v2.8.0
+        with:
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ github.repository }}:latest


### PR DESCRIPTION
GitHub Actions does not have an easy way to specify an image tag for Docker-based actions - so just build/push the latest tag instead