### PR TITLE
Support assigning GitHub teams to review PRs

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Here is a list detailing the assumptions that the Action makes.
 | `head_branch` | The name of the branch changes will be pushed to and the Pull Request will be opened from. | :x: | `bump_image_tags-WXYZ` where `WXYZ` will be a randomly generated ascii string (to avoid clashes) |
 | `labels` | A comma-separated list of labels to apply to the opened Pull Request. Labels must already exist in the repository. | :x: | `[]` |
 | `reviewers` | A comma-separated list of GitHub users (without the leading `@`) to request reviews from. | :x: | `[]` |
+| `team_reviewers` | A comma-separated list of GitHub teams, in the form `ORG_NAME/TEAM_NAME`, to request reviews from. | :x: | `[]` |
 | `dry_run` | Perform a dry-run of the action. A Pull Request will not be opened, but a log message will indicate if any image tags can be bumped. | :x: | `False` |
 
 ## :lock: Permissions

--- a/action.yaml
+++ b/action.yaml
@@ -48,6 +48,11 @@ inputs:
       A comma-separated list of GitHub users (without the leading `@`) to
       request reviews from.
     required: false
+  team_reviewers:
+    description: |
+      A comma-separated list of GitHub teams, in the form ORG_NAME/TEAM_NAME, to
+      request reviews from.
+    required: false
   dry_run:
     description: |
       Perform a dry-run of the action. A Pull Request will not be opened, but a

--- a/tag_bot/_version.py
+++ b/tag_bot/_version.py
@@ -7,5 +7,5 @@ Provides tag_bot version information.
 
 from incremental import Version
 
-__version__ = Version("tag_bot", 1, 1, 0)
+__version__ = Version("tag_bot", 1, 2, 0)
 __all__ = ["__version__"]

--- a/tag_bot/app.py
+++ b/tag_bot/app.py
@@ -219,7 +219,15 @@ def run(
         )
 
         if not pr_exists:
-            create_pr(api_url, header, base_branch, head_branch, labels, reviewers, team_reviewers)
+            create_pr(
+                api_url,
+                header,
+                base_branch,
+                head_branch,
+                labels,
+                reviewers,
+                team_reviewers,
+            )
 
     elif (len(images_to_update) > 0) and dry_run:
         logger.info(

--- a/tag_bot/app.py
+++ b/tag_bot/app.py
@@ -152,6 +152,7 @@ def run(
     head_branch: str,
     labels: list = [],
     reviewers: list = [],
+    team_reviewers: list = [],
     dry_run: bool = False,
 ) -> None:
     """Run the action to check if the docker images are up to date
@@ -169,6 +170,8 @@ def run(
             They must already exist in the repository. Defaults to [].
         reviewers (list, optional): A list of GitHub users to request reviews
             from. Defaults to [].
+        team_reviewers (list, optional): A list of GitHub teams to request reviews from,
+            in the form ORG_NAME/TEAM_NAME. Defaults to [].
         dry_run (bool, optional): Perform a dry-run where a Pull Request will
             not be opened. Defaults to False.
     """
@@ -216,7 +219,7 @@ def run(
         )
 
         if not pr_exists:
-            create_pr(api_url, header, base_branch, head_branch, labels, reviewers)
+            create_pr(api_url, header, base_branch, head_branch, labels, reviewers, team_reviewers)
 
     elif (len(images_to_update) > 0) and dry_run:
         logger.info(

--- a/tag_bot/github_api.py
+++ b/tag_bot/github_api.py
@@ -22,7 +22,9 @@ def add_labels(labels: list, pr_url: str, header: dict) -> None:
     post_request(pr_url, headers=header, json={"labels": labels})
 
 
-def assign_reviewers(reviewers: list, team_reviewers: list, pr_url: str, header: dict) -> None:
+def assign_reviewers(
+    reviewers: list, team_reviewers: list, pr_url: str, header: dict
+) -> None:
     """Request reviews from GitHub users on a Pull Request
 
     Args:
@@ -43,7 +45,11 @@ def assign_reviewers(reviewers: list, team_reviewers: list, pr_url: str, header:
         logger.info("Assigning team reviewers: {}", team_reviewers)
 
     url = "/".join([pr_url, "requested_reviewers"])
-    post_request(url, headers=header, json={"reviewers": reviewers, "team_reviewers": team_reviewers})
+    post_request(
+        url,
+        headers=header,
+        json={"reviewers": reviewers, "team_reviewers": team_reviewers},
+    )
 
 
 def create_pr(

--- a/tag_bot/github_api.py
+++ b/tag_bot/github_api.py
@@ -22,21 +22,28 @@ def add_labels(labels: list, pr_url: str, header: dict) -> None:
     post_request(pr_url, headers=header, json={"labels": labels})
 
 
-def assign_reviewers(reviewers: list, pr_url: str, header: dict) -> None:
+def assign_reviewers(reviewers: list, team_reviewers: list, pr_url: str, header: dict) -> None:
     """Request reviews from GitHub users on a Pull Request
 
     Args:
         reviewers (list): A list of GitHub user to request reviews from
             (**excluding** the leading `@` symbol)
+        team_reviewers (list): A list of GitHub teams to request reviews from, in the
+            form ORG_NAME/TEAM_NAME
         pr_url (str): The API URL of the Pull Request (pulls endpoint) to send
             the request to
         header (dict): A dictionary of headers to send with the request. Must
             contain an authorisation token.
     """
     logger.info("Assigning reviewers to Pull Request: {}", pr_url)
-    logger.info("Assigning reviewers: {}", reviewers)
+
+    if reviewers:
+        logger.info("Assigning reviewers: {}", reviewers)
+    if team_reviewers:
+        logger.info("Assigning team reviewers: {}", team_reviewers)
+
     url = "/".join([pr_url, "requested_reviewers"])
-    post_request(url, headers=header, json={"reviewers": reviewers})
+    post_request(url, headers=header, json={"reviewers": reviewers, team_reviewers})
 
 
 def create_pr(
@@ -46,6 +53,7 @@ def create_pr(
     head_branch: str,
     labels: list,
     reviewers: list,
+    team_reviewers: list,
 ) -> None:
     """Create a Pull Request via the GitHub API
 
@@ -57,6 +65,8 @@ def create_pr(
         head_branch (str): The name of the branch to open the Pull Request from
         labels (list): A list of labels to apply to the Pull Request
         reviewers (list): A list of GitHub users to request reviews from
+        team_reviewers (list): A list of GitHub teams to request reviews from, in the
+            form ORG_NAME/TEAM_NAME
     """
     logger.info("Creating Pull Request...")
 
@@ -71,11 +81,11 @@ def create_pr(
 
     logger.info("Pull Request created!")
 
-    if len(labels) > 0:
+    if labels:
         add_labels(labels, resp["issue_url"], header)
 
-    if len(reviewers) > 0:
-        assign_reviewers(reviewers, resp["url"], header)
+    if reviewers or team_reviewers:
+        assign_reviewers(reviewers, team_reviewers, resp["url"], header)
 
 
 def find_existing_pr(api_url: str, header: dict) -> Tuple[bool, Union[str, None]]:

--- a/tag_bot/github_api.py
+++ b/tag_bot/github_api.py
@@ -43,7 +43,7 @@ def assign_reviewers(reviewers: list, team_reviewers: list, pr_url: str, header:
         logger.info("Assigning team reviewers: {}", team_reviewers)
 
     url = "/".join([pr_url, "requested_reviewers"])
-    post_request(url, headers=header, json={"reviewers": reviewers, team_reviewers})
+    post_request(url, headers=header, json={"reviewers": reviewers, "team_reviewers": team_reviewers})
 
 
 def create_pr(

--- a/tag_bot/http_requests.py
+++ b/tag_bot/http_requests.py
@@ -29,7 +29,7 @@ def get_request(
     resp = requests.get(url, headers=headers, params=params)
 
     if not resp:
-        raise RuntimeError(f"{resp.text}\nRequest URL: {url}")
+        raise requests.HTTPError(f"{resp.text}\nRequest URL: {url}")
 
     if output == "default":
         return resp
@@ -56,7 +56,7 @@ def post_request(
     resp = requests.post(url, headers=headers, json=json)
 
     if not resp:
-        raise RuntimeError(f"{resp.text}\nRequest URL: {url}")
+        raise requests.HTTPError(f"{resp.text}\nRequest URL: {url}")
 
     if return_json:
         return resp.json()

--- a/tag_bot/main.py
+++ b/tag_bot/main.py
@@ -36,7 +36,11 @@ def main():
     )
     labels = os.environ["INPUT_LABELS"] if "INPUT_LABELS" in os.environ else []
     reviewers = os.environ["INPUT_REVIEWERS"] if "INPUT_REVIEWERS" in os.environ else []
-    team_reviewers = os.environ["INPUT_TEAM_REVIEWERS"] if "INPUT_TEAM_REVIEWERS" in os.environ else []
+    team_reviewers = (
+        os.environ["INPUT_TEAM_REVIEWERS"]
+        if "INPUT_TEAM_REVIEWERS" in os.environ
+        else []
+    )
     dry_run = os.environ["INPUT_DRY_RUN"] if "INPUT_DRY_RUN" in os.environ else False
 
     # Reference dict for required inputs

--- a/tag_bot/main.py
+++ b/tag_bot/main.py
@@ -36,6 +36,7 @@ def main():
     )
     labels = os.environ["INPUT_LABELS"] if "INPUT_LABELS" in os.environ else []
     reviewers = os.environ["INPUT_REVIEWERS"] if "INPUT_REVIEWERS" in os.environ else []
+    team_reviewers = os.environ["INPUT_TEAM_REVIEWERS"] if "INPUT_TEAM_REVIEWERS" in os.environ else []
     dry_run = os.environ["INPUT_DRY_RUN"] if "INPUT_DRY_RUN" in os.environ else False
 
     # Reference dict for required inputs
@@ -57,6 +58,8 @@ def main():
         labels = split_str_to_list(labels)
     if len(reviewers) > 0:
         reviewers = split_str_to_list(reviewers)
+    if len(team_reviewers) > 0:
+        team_reviewers = split_str_to_list(team_reviewers)
 
     # Check the dry_run variable is properly set
     if isinstance(dry_run, str) and (dry_run == "true"):
@@ -85,6 +88,7 @@ def main():
         head_branch,
         labels=labels,
         reviewers=reviewers,
+        team_reviewers=team_reviewers,
         dry_run=dry_run,
     )
 

--- a/tests/test_github_api.py
+++ b/tests/test_github_api.py
@@ -22,13 +22,13 @@ def test_assign_reviewers():
     test_reviewers = ["reviewer1", "reviewer2"]
 
     with patch("tag_bot.github_api.post_request") as mocked_func:
-        assign_reviewers(test_reviewers, test_url, test_header)
+        assign_reviewers(test_reviewers, [], test_url, test_header)
 
         assert mocked_func.call_count == 1
         mocked_func.assert_called_with(
             "/".join([test_url, "requested_reviewers"]),
             headers=test_header,
-            json={"reviewers": test_reviewers},
+            json={"reviewers": test_reviewers, "team_reviewers": []},
         )
 
 
@@ -37,6 +37,7 @@ def test_create_pr_no_labels_no_reviewers():
     test_head_branch = "head"
     test_labels = []
     test_reviewers = []
+    test_team_reviewers = []
 
     expected_pr = {
         "title": "Bumping Docker image tags",
@@ -53,6 +54,7 @@ def test_create_pr_no_labels_no_reviewers():
             test_head_branch,
             labels=test_labels,
             reviewers=test_reviewers,
+            team_reviewers=test_team_reviewers,
         )
 
         assert mocked_func.call_count == 1
@@ -69,6 +71,7 @@ def test_create_pr_with_labels_no_reviewers():
     test_head_branch = "head"
     test_labels = ["label1", "label2"]
     test_reviewers = []
+    test_team_reviewers = []
 
     expected_pr = {
         "title": "Bumping Docker image tags",
@@ -91,6 +94,7 @@ def test_create_pr_with_labels_no_reviewers():
             test_head_branch,
             labels=test_labels,
             reviewers=test_reviewers,
+            team_reviewers=test_team_reviewers,
         )
 
         assert mock1.call_count == 1
@@ -112,6 +116,7 @@ def test_create_pr_no_labels_with_reviewers():
     test_head_branch = "head"
     test_labels = []
     test_reviewers = ["reviewer1", "reviewer2"]
+    test_team_reviewers = []
 
     expected_pr = {
         "title": "Bumping Docker image tags",
@@ -134,6 +139,7 @@ def test_create_pr_no_labels_with_reviewers():
             test_head_branch,
             labels=test_labels,
             reviewers=test_reviewers,
+            team_reviewers=test_team_reviewers,
         )
 
         assert mock1.call_count == 1
@@ -146,7 +152,7 @@ def test_create_pr_no_labels_with_reviewers():
         )
         assert mock2.call_count == 1
         mock2.assert_called_with(
-            test_reviewers, "/".join([test_url, "pulls", "1"]), test_header
+            test_reviewers, test_team_reviewers, "/".join([test_url, "pulls", "1"]), test_header
         )
 
 
@@ -155,6 +161,7 @@ def test_create_pr_with_labels_and_reviewers():
     test_head_branch = "head"
     test_labels = ["label1", "label2"]
     test_reviewers = ["reviewer1", "reviewer2"]
+    test_team_reviewers = []
 
     expected_pr = {
         "title": "Bumping Docker image tags",
@@ -181,6 +188,7 @@ def test_create_pr_with_labels_and_reviewers():
             test_head_branch,
             labels=test_labels,
             reviewers=test_reviewers,
+            team_reviewers=test_team_reviewers,
         )
 
         assert mock1.call_count == 1
@@ -200,7 +208,7 @@ def test_create_pr_with_labels_and_reviewers():
         )
         assert mock3.call_count == 1
         mock3.assert_called_with(
-            test_reviewers, "/".join([test_url, "pulls", "1"]), test_header
+            test_reviewers, test_team_reviewers, "/".join([test_url, "pulls", "1"]), test_header
         )
 
 

--- a/tests/test_github_api.py
+++ b/tests/test_github_api.py
@@ -152,7 +152,10 @@ def test_create_pr_no_labels_with_reviewers():
         )
         assert mock2.call_count == 1
         mock2.assert_called_with(
-            test_reviewers, test_team_reviewers, "/".join([test_url, "pulls", "1"]), test_header
+            test_reviewers,
+            test_team_reviewers,
+            "/".join([test_url, "pulls", "1"]),
+            test_header,
         )
 
 
@@ -208,7 +211,10 @@ def test_create_pr_with_labels_and_reviewers():
         )
         assert mock3.call_count == 1
         mock3.assert_called_with(
-            test_reviewers, test_team_reviewers, "/".join([test_url, "pulls", "1"]), test_header
+            test_reviewers,
+            test_team_reviewers,
+            "/".join([test_url, "pulls", "1"]),
+            test_header,
         )
 
 

--- a/tests/test_http_requests.py
+++ b/tests/test_http_requests.py
@@ -43,7 +43,7 @@ def test_get_request_text():
 
 
 def test_get_request_output_exception():
-    with pytest.raises(requests.HTTPError):
+    with pytest.raises(ValueError):
         _ = get_request(test_url, headers=test_header, output="yaml")
 
 

--- a/tests/test_http_requests.py
+++ b/tests/test_http_requests.py
@@ -1,6 +1,6 @@
 import pytest
-import responses
 import requests
+import responses
 
 from tag_bot.http_requests import get_request, post_request
 

--- a/tests/test_http_requests.py
+++ b/tests/test_http_requests.py
@@ -1,5 +1,6 @@
 import pytest
 import responses
+import requests
 
 from tag_bot.http_requests import get_request, post_request
 
@@ -42,7 +43,7 @@ def test_get_request_text():
 
 
 def test_get_request_output_exception():
-    with pytest.raises(ValueError):
+    with pytest.raises(requests.HTTPError):
         _ = get_request(test_url, headers=test_header, output="yaml")
 
 
@@ -50,7 +51,7 @@ def test_get_request_output_exception():
 def test_get_request_url_exception():
     responses.add(responses.GET, test_url, status=500)
 
-    with pytest.raises(RuntimeError):
+    with pytest.raises(requests.HTTPError):
         _ = get_request(test_url, headers=test_header)
 
     assert len(responses.calls) == 1
@@ -82,7 +83,7 @@ def test_post_request_return_json():
 def test_post_request_exception():
     responses.add(responses.POST, test_url, status=500)
 
-    with pytest.raises(RuntimeError):
+    with pytest.raises(requests.HTTPError):
         post_request(test_url, headers=test_header, json=test_body)
 
     assert len(responses.calls) == 1


### PR DESCRIPTION
This PR adds support for assigning GitHub Teams as reviewers to the opened PR