### PR TITLE
Swap pyyaml for ruamel

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
-# Use a Python 3.9 slim image
+# Use a Python slim image
 FROM python:3.10.2-slim
+
+# Install gcc
+RUN apt-get update && apt-get install --yes gcc
 
 # Create and set the 'app' working directory
 RUN mkdir /app

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ incremental==21.3.0
 jmespath==1.0.0
 loguru==0.6.0
 requests==2.27.1
-ruamel.yaml==0.2.6
+ruamel.yaml>=0.2.6
 twisted==22.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 incremental==21.3.0
 jmespath==1.0.0
 loguru==0.6.0
-PyYAML==6.0
 requests==2.27.1
+ruamel.yaml==0.2.6
 twisted==22.4.0

--- a/tag_bot/app.py
+++ b/tag_bot/app.py
@@ -3,7 +3,6 @@ import random
 import string
 from itertools import compress
 
-import yaml
 from loguru import logger
 
 from .git_database import create_commit, create_ref, get_contents, get_ref
@@ -15,6 +14,9 @@ from .utils import (
     lookup_key_return_path,
     update_config_with_jq,
 )
+from .yaml_parser import YamlParser
+
+yaml = YamlParser()
 
 
 def edit_config(
@@ -38,7 +40,7 @@ def edit_config(
         file_contents (str): The updated JupyterHub config in YAML format and encoded in base64
     """
     resp = get_request(download_url, headers=header, output="text")
-    file_contents = yaml.safe_load(resp)
+    file_contents = yaml.yaml_string_to_object(resp)
     lookup_dict = create_reverse_lookup_dict(file_contents)
 
     logger.info("Updating JupyterHub config...")
@@ -63,7 +65,7 @@ def edit_config(
 
     # Encode the file contents
     logger.info("Encoding config in base64...")
-    encoded_file_contents = yaml.safe_dump(file_contents).encode("utf-8")
+    encoded_file_contents = yaml.object_to_yaml_str(file_contents).encode("utf-8")
     base64_bytes = base64.b64encode(encoded_file_contents)
     file_contents = base64_bytes.decode("utf-8")
 

--- a/tag_bot/parse_image_tags.py
+++ b/tag_bot/parse_image_tags.py
@@ -1,14 +1,16 @@
 from datetime import datetime
 
-import yaml
 from loguru import logger
 
 from .http_requests import get_request
+from .yaml_parser import YamlParser
 
 API_ROOT = "https://api.github.com"
 RAW_ROOT = "https://raw.githubusercontent.com"
 DOCKERHUB_ROOT = "https://hub.docker.com/v2/repositories"
 QUAYIO_ROOT = "https://quay.io/api/v1/repository"
+
+yaml = YamlParser()
 
 
 def get_deployed_image_tags(
@@ -35,7 +37,7 @@ def get_deployed_image_tags(
     api_url = api_url.replace(API_ROOT + "/repos", RAW_ROOT)
     url = "/".join([api_url, branch, filepath])
     resp = get_request(url, headers=header, output="text")
-    config = yaml.safe_load(resp)
+    config = yaml.yaml_string_to_object(resp)
 
     if "singleuser" in config.keys():
         image_tags[config["singleuser"]["image"]["name"]] = {

--- a/tag_bot/yaml_parser.py
+++ b/tag_bot/yaml_parser.py
@@ -1,0 +1,33 @@
+import ruamel.yaml
+from io import StringIO
+
+
+def represent_none(self, data):
+    return self.represent_scalar(u"tag:yaml.org,2002:null", u"null")
+
+
+class YamlParser:
+    def __init__(self):
+        self.yaml = ruamel.yaml.YAML()
+        self.yaml.indent(mapping=3, sequence=2, offset=0)
+        self.yaml.allow_duplicate_keys = True
+        self.yaml.explicit_start = False
+        self.yaml.representer.add_representer(type(None), represent_none)
+
+    def object_to_yaml_str(self, obj, options={}):
+        string_stream = StringIO()
+        self.yaml.dump(obj, string_stream, **options)
+        output_str = string_stream.getvalue()
+        string_stream.close()
+
+        return output_str
+
+    def yaml_string_to_object(self, string, options={}):
+        return self.yaml.load(string, **options)
+
+    def yaml_file_to_object(self, file_path, options={}):
+        return self.yaml.load(file_path, **options)
+
+    def object_to_yaml_file(self, obj, file_path, options={}):
+        with open(file_path, "w") as fp:
+            self.yaml.dump(obj, fp, **options)

--- a/tag_bot/yaml_parser.py
+++ b/tag_bot/yaml_parser.py
@@ -1,9 +1,10 @@
-import ruamel.yaml
 from io import StringIO
+
+import ruamel.yaml
 
 
 def represent_none(self, data):
-    return self.represent_scalar(u"tag:yaml.org,2002:null", u"null")
+    return self.represent_scalar("tag:yaml.org,2002:null", "null")
 
 
 class YamlParser:

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -4,9 +4,10 @@
 import base64
 from unittest.mock import patch
 
-import yaml
-
 from tag_bot.app import compare_image_tags, edit_config
+from tag_bot.yaml_parser import YamlParser
+
+yaml = YamlParser()
 
 test_url = "http://jsonplaceholder.typicode.com"
 test_header = {"Authorization": "token ThIs_Is_A_ToKeN"}
@@ -27,7 +28,7 @@ def test_edit_config_singleuser():
             "image": {"name": "image_owner/image_name", "tag": "new_image_tag"},
         }
     }
-    expected_output = yaml.safe_dump(expected_output).encode("utf-8")
+    expected_output = yaml.object_to_yaml_str(expected_output).encode("utf-8")
     expected_output = base64.b64encode(expected_output)
     expected_output = expected_output.decode("utf-8")
 
@@ -75,7 +76,7 @@ def test_edit_config_profileList():
             ]
         }
     }
-    expected_output = yaml.safe_dump(expected_output).encode("utf-8")
+    expected_output = yaml.object_to_yaml_str(expected_output).encode("utf-8")
     expected_output = base64.b64encode(expected_output)
     expected_output = expected_output.decode("utf-8")
 
@@ -135,7 +136,7 @@ def test_edit_config_both():
             ],
         }
     }
-    expected_output = yaml.safe_dump(expected_output).encode("utf-8")
+    expected_output = yaml.object_to_yaml_str(expected_output).encode("utf-8")
     expected_output = base64.b64encode(expected_output)
     expected_output = expected_output.decode("utf-8")
 

--- a/tests/test_git_database.py
+++ b/tests/test_git_database.py
@@ -1,9 +1,10 @@
 import base64
 from unittest.mock import patch
 
-import yaml
-
 from tag_bot.git_database import create_commit, create_ref, get_contents, get_ref
+from tag_bot.yaml_parser import YamlParser
+
+yaml = YamlParser()
 
 test_url = "http://jsonplaceholder.typicode.com"
 test_header = {"Authorization": "token ThIs_Is_A_ToKeN"}
@@ -16,7 +17,7 @@ def test_create_commit():
     test_commit_msg = "This is a commit message"
 
     test_contents = {"key1": "This is a test"}
-    test_contents = yaml.safe_dump(test_contents).encode("utf-8")
+    test_contents = yaml.object_to_yaml_str(test_contents).encode("utf-8")
     test_contents = base64.b64encode(test_contents)
     test_contents = test_contents.decode("utf-8")
 


### PR DESCRIPTION
 pyyaml is not maintained anymore, so we prefer ruamel. But ruamel forces us to always dump to a stream, which makes the encoding section of committing changes difficult. Hence we introduce a YamlParser class that will handle various obj<->str/obj<->file conversions as we require