### PR TITLE
Support opening forks for Pull Requests

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -58,6 +58,13 @@ inputs:
       A comma-separated list of GitHub teams, in the form ORG_NAME/TEAM_NAME, to
       request reviews from.
     required: false
+  push_to_users_fork:
+    description: |
+      The username to create a fork of the repository under. The Pull Request will be
+      opened from a branch in this repository. IMPORTANT: If using this option, then
+      GITHUB_TOKEN should be a PAT from the user account where the repository will be
+      forked to.
+    required: false
   dry_run:
     description: |
       Perform a dry-run of the action. A Pull Request will not be opened, but a

--- a/tag_bot/github_api.py
+++ b/tag_bot/github_api.py
@@ -154,7 +154,7 @@ class GitHubAPI:
         if self.pr_exists:
             logger.info("Updating Pull Request...")
 
-            url = "/".join([url, self.pr_number])
+            url = "/".join([url, str(self.pr_number)])
             pr["state"] = "open"
             resp = patch_request(
                 url, headers=self.inputs.headers, json=pr, return_json=True

--- a/tag_bot/github_api.py
+++ b/tag_bot/github_api.py
@@ -40,20 +40,20 @@ class GitHubAPI:
                 the request to
         """
         logger.info("Assigning reviewers to Pull Request: {}", pr_url)
+        body = {}
 
         if self.inputs.reviewers:
             logger.info("Assigning reviewers: {}", self.inputs.reviewers)
+            body["reviewers"] = self.inputs.reviewers
         if self.inputs.team_reviewers:
             logger.info("Assigning team reviewers: {}", self.inputs.team_reviewers)
+            body["team_reviewers"] = self.inputs.team_reviewers
 
         url = "/".join([pr_url, "requested_reviewers"])
         post_request(
             url,
             headers=self.inputs.headers,
-            json={
-                "reviewers": self.inputs.reviewers,
-                "team_reviewers": self.inputs.team_reviewers,
-            },
+            json=body,
         )
 
     def create_commit(self, commit_msg, content):

--- a/tag_bot/parse_image_tags.py
+++ b/tag_bot/parse_image_tags.py
@@ -34,12 +34,12 @@ class ImageTags:
         """
         url = "/".join([self.github_api_url, "contents", self.inputs.config_path])
         query = {"ref": ref}
-        resp = get_request(url, headers=self.headers, params=query, output="json")
+        resp = get_request(url, headers=self.inputs.headers, params=query, output="json")
 
         download_url = resp["download_url"]
         sha = resp["sha"]
 
-        resp = get_request(download_url, headers=self.headers, output="text")
+        resp = get_request(download_url, headers=self.inputs.headers, output="text")
         return yaml.yaml_string_to_object(resp), sha
 
     def _get_local_image_tags(self):

--- a/tag_bot/parse_image_tags.py
+++ b/tag_bot/parse_image_tags.py
@@ -17,12 +17,10 @@ class ImageTags:
     published version on a container repository and update if needed.
     """
 
-    def __init__(self, inputs, branch):
+    def __init__(self, inputs, repository, branch):
         self.inputs = inputs
         self.branch = branch
-        self.github_api_url = "/".join(
-            ["https://api.github.com", "repos", self.inputs.repository]
-        )
+        self.github_api_url = "/".join(["https://api.github.com", "repos", repository])
         self.image_tags = {}
 
     def _get_config(self, ref):

--- a/tag_bot/parse_image_tags.py
+++ b/tag_bot/parse_image_tags.py
@@ -34,7 +34,9 @@ class ImageTags:
         """
         url = "/".join([self.github_api_url, "contents", self.inputs.config_path])
         query = {"ref": ref}
-        resp = get_request(url, headers=self.inputs.headers, params=query, output="json")
+        resp = get_request(
+            url, headers=self.inputs.headers, params=query, output="json"
+        )
 
         download_url = resp["download_url"]
         sha = resp["sha"]

--- a/tag_bot/yaml_parser.py
+++ b/tag_bot/yaml_parser.py
@@ -25,10 +25,3 @@ class YamlParser:
 
     def yaml_string_to_object(self, string, options={}):
         return self.yaml.load(string, **options)
-
-    def yaml_file_to_object(self, file_path, options={}):
-        return self.yaml.load(file_path, **options)
-
-    def object_to_yaml_file(self, obj, file_path, options={}):
-        with open(file_path, "w") as fp:
-            self.yaml.dump(obj, fp, **options)

--- a/tests/test_github_api.py
+++ b/tests/test_github_api.py
@@ -529,11 +529,19 @@ class TestGitHubAPI(unittest.TestCase):
             self.assertDictEqual(resp, {"object": {"sha": "sha"}})
 
     def test_check_fork_exists_true(self):
-        main = UpdateImageTags("octocat/octocat", "ThIs_Is_A_t0k3n", "config/config.yaml", [".singleuser.image"])
+        main = UpdateImageTags(
+            "octocat/octocat",
+            "ThIs_Is_A_t0k3n",
+            "config/config.yaml",
+            [".singleuser.image"],
+        )
         github = GitHubAPI(main)
         main.push_to_users_fork = "user1/octocat"
 
-        mock_get = patch("tag_bot.github_api.get_request", return_value=[{"full_name": "user1/octocat"}])
+        mock_get = patch(
+            "tag_bot.github_api.get_request",
+            return_value=[{"full_name": "user1/octocat"}],
+        )
 
         with mock_get as mock:
             github.check_fork_exists()
@@ -546,11 +554,19 @@ class TestGitHubAPI(unittest.TestCase):
             )
 
     def test_check_fork_exists_false(self):
-        main = UpdateImageTags("octocat/octocat", "ThIs_Is_A_t0k3n", "config/config.yaml", [".singleuser.image"])
+        main = UpdateImageTags(
+            "octocat/octocat",
+            "ThIs_Is_A_t0k3n",
+            "config/config.yaml",
+            [".singleuser.image"],
+        )
         github = GitHubAPI(main)
         main.push_to_users_fork = "user1/octocat"
 
-        mock_get = patch("tag_bot.github_api.get_request", return_value=[{"full_name": "user2/octocat"}])
+        mock_get = patch(
+            "tag_bot.github_api.get_request",
+            return_value=[{"full_name": "user2/octocat"}],
+        )
 
         with mock_get as mock:
             github.check_fork_exists()
@@ -563,7 +579,13 @@ class TestGitHubAPI(unittest.TestCase):
             )
 
     def test_create_fork(self):
-        main = UpdateImageTags("octocat/octocat", "ThIs_Is_A_t0k3n", "config/config.yaml", [".singleuser.image"], push_to_users_fork="user1")
+        main = UpdateImageTags(
+            "octocat/octocat",
+            "ThIs_Is_A_t0k3n",
+            "config/config.yaml",
+            [".singleuser.image"],
+            push_to_users_fork="user1",
+        )
         github = GitHubAPI(main)
 
         mock_post = patch("tag_bot.github_api.post_request")
@@ -577,9 +599,16 @@ class TestGitHubAPI(unittest.TestCase):
             )
 
     def test_merge_upstream(self):
-        main = UpdateImageTags("octocat/octocat", "ThIs_Is_A_t0k3n", "config/config.yaml", [".singleuser.image"])
+        main = UpdateImageTags(
+            "octocat/octocat",
+            "ThIs_Is_A_t0k3n",
+            "config/config.yaml",
+            [".singleuser.image"],
+        )
         github = GitHubAPI(main)
-        github.fork_api_url = "/".join(["https://api.github.com", "repos", "user", "octocat"])
+        github.fork_api_url = "/".join(
+            ["https://api.github.com", "repos", "user", "octocat"]
+        )
 
         mock_post = patch("tag_bot.github_api.post_request")
 
@@ -593,7 +622,12 @@ class TestGitHubAPI(unittest.TestCase):
             )
 
     def test_update_existing_pr(self):
-        main = UpdateImageTags("octocat/octocat", "ThIs_Is_A_t0k3n", "config/config.yaml", [".singleuser.image"])
+        main = UpdateImageTags(
+            "octocat/octocat",
+            "ThIs_Is_A_t0k3n",
+            "config/config.yaml",
+            [".singleuser.image"],
+        )
         github = GitHubAPI(main)
         github.pr_exists = True
         main.image_tags = {"image": {"current": "old_tag", "latest": "new_tag"}}
@@ -614,7 +648,9 @@ class TestGitHubAPI(unittest.TestCase):
             "state": "open",
         }
 
-        mock_patch = patch("tag_bot.github_api.patch_request", return_value={"number": 1})
+        mock_patch = patch(
+            "tag_bot.github_api.patch_request", return_value={"number": 1}
+        )
 
         with mock_patch as mock:
             github.create_update_pull_request()

--- a/tests/test_github_api.py
+++ b/tests/test_github_api.py
@@ -594,6 +594,7 @@ class TestGitHubAPI(unittest.TestCase):
         )
         github = GitHubAPI(main)
         github.pr_exists = True
+        github.pr_number = 1
         main.image_tags = {"image": {"current": "old_tag", "latest": "new_tag"}}
         main.images_to_update = ["image"]
 
@@ -620,7 +621,7 @@ class TestGitHubAPI(unittest.TestCase):
             github.create_update_pull_request()
 
             mock.assert_called_with(
-                "/".join([github.api_url, "pulls"]),
+                "/".join([github.api_url, "pulls", str(github.pr_number)]),
                 headers=main.headers,
                 json=expected_pr,
                 return_json=True,

--- a/tests/test_github_api.py
+++ b/tests/test_github_api.py
@@ -47,7 +47,7 @@ class TestGitHubAPI(unittest.TestCase):
             mock.assert_called_with(
                 "/".join([pr_url, "requested_reviewers"]),
                 headers=main.headers,
-                json={"reviewers": main.reviewers, "team_reviewers": []},
+                json={"reviewers": main.reviewers},
             )
 
     def test_create_pr_no_labels_no_reviewers(self):
@@ -227,7 +227,7 @@ class TestGitHubAPI(unittest.TestCase):
             call(
                 "/".join([github.api_url, "pulls", "1", "requested_reviewers"]),
                 headers=main.headers,
-                json={"reviewers": main.reviewers, "team_reviewers": []},
+                json={"reviewers": main.reviewers},
             ),
         ]
 
@@ -307,7 +307,7 @@ class TestGitHubAPI(unittest.TestCase):
             call(
                 "/".join([github.api_url, "pulls", "1", "requested_reviewers"]),
                 headers=main.headers,
-                json={"reviewers": main.reviewers, "team_reviewers": []},
+                json={"reviewers": main.reviewers},
             ),
         ]
 

--- a/tests/test_parse_image_tags.py
+++ b/tests/test_parse_image_tags.py
@@ -203,6 +203,28 @@ class TestImageTags(unittest.TestCase):
 
         self.assertEqual(result, expected)
 
+    @patch("tag_bot.parse_image_tags.get_request")
+    def test_get_config(self, mock_get):
+        main = UpdateImageTags("octocat/octocat", "t0k3n", "config/config.yaml", [".singleuser.image"])
+        image_parser = ImageTags(main, main.repository, main.base_branch)
+
+        mock_get.side_effect = [
+            {
+                "download_url": "https://example.com",
+                "sha": "123456789",
+            },
+            "hello: world",
+        ]
+
+        expected_config = {"hello": "world"}
+        expected_sha = "123456789"
+
+        with mock_get as mock:
+            config, sha = image_parser._get_config(main.base_branch)
+
+            self.assertDictEqual(config, expected_config)
+            self.assertEqual(sha, expected_sha)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_parse_image_tags.py
+++ b/tests/test_parse_image_tags.py
@@ -221,11 +221,10 @@ class TestImageTags(unittest.TestCase):
         expected_config = {"hello": "world"}
         expected_sha = "123456789"
 
-        with mock_get as mock:
-            config, sha = image_parser._get_config(main.base_branch)
+        config, sha = image_parser._get_config(main.base_branch)
 
-            self.assertDictEqual(config, expected_config)
-            self.assertEqual(sha, expected_sha)
+        self.assertDictEqual(config, expected_config)
+        self.assertEqual(sha, expected_sha)
 
 
 if __name__ == "__main__":

--- a/tests/test_parse_image_tags.py
+++ b/tests/test_parse_image_tags.py
@@ -205,7 +205,9 @@ class TestImageTags(unittest.TestCase):
 
     @patch("tag_bot.parse_image_tags.get_request")
     def test_get_config(self, mock_get):
-        main = UpdateImageTags("octocat/octocat", "t0k3n", "config/config.yaml", [".singleuser.image"])
+        main = UpdateImageTags(
+            "octocat/octocat", "t0k3n", "config/config.yaml", [".singleuser.image"]
+        )
         image_parser = ImageTags(main, main.repository, main.base_branch)
 
         mock_get.side_effect = [

--- a/tests/test_parse_image_tags.py
+++ b/tests/test_parse_image_tags.py
@@ -13,7 +13,7 @@ class TestImageTags(unittest.TestCase):
             "config/config.yaml",
             [".singleuser.image"],
         )
-        image_parser = ImageTags(main, "main")
+        image_parser = ImageTags(main, "octocat/octocat", "main")
         image_parser.inputs.config = {
             "singleuser": {
                 "image": {
@@ -41,7 +41,7 @@ class TestImageTags(unittest.TestCase):
             "config/config.yaml",
             [".singleuser.profileList[0].kubespawner_override.image"],
         )
-        image_parser = ImageTags(main, "main")
+        image_parser = ImageTags(main, "octocat/octocat", "main")
         image_parser.inputs.config = {
             "singleuser": {
                 "profileList": [
@@ -72,7 +72,7 @@ class TestImageTags(unittest.TestCase):
             "config/config.yaml",
             [".singleuser.image"],
         )
-        image_parser = ImageTags(main, "main")
+        image_parser = ImageTags(main, "octocat/octocat", "main")
         image_parser.image_tags = {"image_owner/image_name": {"current": "image_tag"}}
         image = "image_owner/image_name"
 
@@ -120,7 +120,7 @@ class TestImageTags(unittest.TestCase):
             "config/config.yaml",
             [".singleuser.image"],
         )
-        image_parser = ImageTags(main, "main")
+        image_parser = ImageTags(main, "octocat/octocat", "main")
         image_parser.image_tags = {"image_owner/image_name": {"current": "image_tag"}}
         image = "image_owner/image_name"
 
@@ -168,7 +168,7 @@ class TestImageTags(unittest.TestCase):
             "config/config.yaml",
             [".singleuser.image"],
         )
-        image_parser = ImageTags(main, "main")
+        image_parser = ImageTags(main, "octocat/octocat", "main")
         image_parser.image_tags = {
             "image_name": {
                 "current": "image_name",
@@ -189,7 +189,7 @@ class TestImageTags(unittest.TestCase):
             "config/config.yaml",
             [".singleuser.image"],
         )
-        image_parser = ImageTags(main, "main")
+        image_parser = ImageTags(main, "octocat/octocat", "main")
         image_parser.image_tags = {
             "image_name": {
                 "current": "image_name",


### PR DESCRIPTION
fixes #106 

This PR brings in the ability to fork the repository should users wish. They provide the name of a user account to fork the repository to and a token owned by that account.