### PR TITLE
[BUGFIX] If a PR exists, retrieve it's number so it can be updated

### DIFF
--- a/tag_bot/github_api.py
+++ b/tag_bot/github_api.py
@@ -109,6 +109,7 @@ class GitHubAPI:
         if self.pr_exists:
             logger.info("Updating Pull Request...")
 
+            url = "/".join([url, self.pr_number])
             pr["state"] = "open"
             resp = patch_request(
                 url, headers=self.inputs.headers, json=pr, return_json=True
@@ -143,19 +144,20 @@ class GitHubAPI:
 
         head_label_exp = jmespath.compile("[*].head.label")
         matches = head_label_exp.search(resp)
-        matches = [label for label in matches if self.inputs.head_branch in label]
+        indx, match = next(((indx, match) for (indx, match) in enumerate(matches) if self.inputs.head_branch in match), (None, None))
 
-        if (len(matches) > 1) or (len(matches) == 1):
-            logger.info("Pull Request found!")
-            self.inputs.head_branch = matches[0].split(":")[-1]
-            self.pr_exists = True
-        else:
+        if (indx is None) and (match is None):
             logger.info(
                 "No relevant Pull Requests found. A new Pull Request will be opened."
             )
             random_id = "".join(random.sample(string.ascii_letters, 4))
             self.inputs.head_branch = "-".join([self.inputs.head_branch, random_id])
             self.pr_exists = False
+        else:
+            logger.info("Pull Request found!")
+            self.inputs.head_branch = match.split(":")[-1]
+            self.pr_number = resp[indx]["number"]
+            self.pr_exists = True
 
     def get_ref(self, ref):
         """Get a git reference (specifically, a HEAD ref) using GitHub's git

--- a/tag_bot/github_api.py
+++ b/tag_bot/github_api.py
@@ -144,7 +144,14 @@ class GitHubAPI:
 
         head_label_exp = jmespath.compile("[*].head.label")
         matches = head_label_exp.search(resp)
-        indx, match = next(((indx, match) for (indx, match) in enumerate(matches) if self.inputs.head_branch in match), (None, None))
+        indx, match = next(
+            (
+                (indx, match)
+                for (indx, match) in enumerate(matches)
+                if self.inputs.head_branch in match
+            ),
+            (None, None),
+        )
 
         if (indx is None) and (match is None):
             logger.info(

--- a/tests/test_github_api.py
+++ b/tests/test_github_api.py
@@ -354,7 +354,7 @@ class TestGitHubAPI(unittest.TestCase):
             self.assertFalse(github.pr_exists)
             self.assertTrue(main.head_branch.startswith("bump-image-tags-"))
 
-    def test_find_existing_pr_one_match(self):
+    def test_find_existing_pr_match(self):
         main = UpdateImageTags(
             "octocat/octocat",
             "token ThIs_Is_A_ToKeN",
@@ -368,7 +368,8 @@ class TestGitHubAPI(unittest.TestCase):
                 {
                     "head": {
                         "label": "bump-image-tags",
-                    }
+                    },
+                    "number": 1,
                 }
             ],
         )
@@ -385,43 +386,6 @@ class TestGitHubAPI(unittest.TestCase):
             )
             self.assertTrue(github.pr_exists)
             self.assertEqual(main.head_branch, "bump-image-tags")
-
-    def test_find_existing_pr_multiple_matches(self):
-        main = UpdateImageTags(
-            "octocat/octocat",
-            "token ThIs_Is_A_ToKeN",
-            "config/config.yaml",
-            [".singleuser.image"],
-        )
-        github = GitHubAPI(main)
-        mock_get = patch(
-            "tag_bot.github_api.get_request",
-            return_value=[
-                {
-                    "head": {
-                        "label": "bump-image-tags1",
-                    }
-                },
-                {
-                    "head": {
-                        "label": "bump-image-tags2",
-                    }
-                },
-            ],
-        )
-
-        with mock_get as mock:
-            github.find_existing_pull_request()
-
-            self.assertEqual(mock.call_count, 1)
-            mock.assert_called_with(
-                "/".join([github.api_url, "pulls"]),
-                headers=main.headers,
-                params={"state": "open", "sort": "created", "direction": "desc"},
-                output="json",
-            )
-            self.assertTrue(github.pr_exists)
-            self.assertEqual(main.head_branch, "bump-image-tags1")
 
     def test_create_commit(self):
         main = UpdateImageTags(


### PR DESCRIPTION
Updating a PR would fail because we were not appending the number of the PR to the URL the patch request was sent to