### PR TITLE
Change branch separator character for Dependabot PRs

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -8,6 +8,8 @@ updates:
       day: "monday"
       time: "00:00"
       timezone: "Europe/London"
+    pull-request-branch-name:
+      separator: "-"
   # Maintain dependencies for pip
   - package-ecosystem: "pip"
     directory: "/"
@@ -19,6 +21,8 @@ updates:
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-patch"]
+    pull-request-branch-name:
+      separator: "-"
   # Maintain dependencies for docker
   - package-ecosystem: "docker"
     directory: "/"
@@ -30,3 +34,5 @@ updates:
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-patch"]
+    pull-request-branch-name:
+      separator: "-"

--- a/.github/workflows/docker-build-push.yaml
+++ b/.github/workflows/docker-build-push.yaml
@@ -1,4 +1,4 @@
-name: Build and Push Docker Image
+name: Test Building Docker Image
 
 on:
   push:
@@ -13,11 +13,11 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     steps:
-      - name: Build
+      - name: Test Docker Build
         uses: docker/build-push-action@v3.0.0
         with:
           push: false
-          tags: ${{ github.repository }}:latest
+          tags: ${{ github.repository }}:${{ github.head_ref }}
 
   docker-build-push:
     runs-on: ubuntu-latest
@@ -30,7 +30,7 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
-      - name: Build and push
+      - name: Build and Push Image
         uses: docker/build-push-action@v3.0.0
         with:
           push: true


### PR DESCRIPTION
This allows us to use `hed_ref` in GitHub Actions as a valid Docker image tag