### PR TITLE
Refactor Yaml Parser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # Ignore test outputs
-tests/assests/**output.yaml
+tests/assets/**output.yaml
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Ignore test outputs
+tests/assests/**output.yaml
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/action.yaml
+++ b/action.yaml
@@ -72,7 +72,7 @@ inputs:
     required: false
 runs:
   using: 'docker'
-  image: 'docker://sgibson91/bump-jhub-image-action:tweak-yaml-parser'
+  image: 'docker://sgibson91/bump-jhub-image-action'
 branding:
   icon: check-circle
   color: purple

--- a/action.yaml
+++ b/action.yaml
@@ -72,7 +72,7 @@ inputs:
     required: false
 runs:
   using: 'docker'
-  image: 'docker://sgibson91/bump-jhub-image-action'
+  image: 'docker://sgibson91/bump-jhub-image-action:tweak-yaml-parser'
 branding:
   icon: check-circle
   color: purple

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ incremental==21.3.0
 jmespath==1.0.0
 loguru==0.6.0
 requests==2.27.1
-ruamel.yaml>=0.2.6
+ruamel.yaml==0.17.21
 twisted==22.4.0

--- a/tag_bot/main.py
+++ b/tag_bot/main.py
@@ -72,9 +72,8 @@ class UpdateImageTags:
                 )
 
         logger.info("Encoding config in base64...")
-        encoded_config = yaml.object_to_yaml_str(self.config).encode("utf-8")
-        base64_bytes = base64.b64encode(encoded_config)
-        config = base64_bytes.decode("utf-8")
+        config = yaml.object_to_yaml_str(self.config).encode("utf-8")
+        config = base64.b64encode(config).decode("utf-8")
 
         return config
 

--- a/tag_bot/yaml_parser.py
+++ b/tag_bot/yaml_parser.py
@@ -6,6 +6,10 @@ import ruamel.yaml
 class YamlParser:
     def __init__(self):
         self.yaml = ruamel.yaml.YAML()
+        self.yaml.indent(mapping=2, sequence=2, offset=2)
+        self.yaml.allow_duplicate_keys = True
+        self.yaml.explicit_start = False
+        self.yaml.preserve_quotes = True
 
     def object_to_yaml_str(self, obj, options={}):
         string_stream = StringIO()

--- a/tag_bot/yaml_parser.py
+++ b/tag_bot/yaml_parser.py
@@ -3,17 +3,9 @@ from io import StringIO
 import ruamel.yaml
 
 
-def represent_none(self, data):
-    return self.represent_scalar("tag:yaml.org,2002:null", "null")
-
-
 class YamlParser:
     def __init__(self):
-        self.yaml = ruamel.yaml.YAML()
-        self.yaml.indent(mapping=3, sequence=2, offset=0)
-        self.yaml.allow_duplicate_keys = True
-        self.yaml.explicit_start = False
-        self.yaml.representer.add_representer(type(None), represent_none)
+        self.yaml = ruamel.yaml.YAML(typ="safe", pure=True)
 
     def object_to_yaml_str(self, obj, options={}):
         string_stream = StringIO()

--- a/tag_bot/yaml_parser.py
+++ b/tag_bot/yaml_parser.py
@@ -5,7 +5,7 @@ import ruamel.yaml
 
 class YamlParser:
     def __init__(self):
-        self.yaml = ruamel.yaml.YAML(typ="safe", pure=True)
+        self.yaml = ruamel.yaml.YAML()
 
     def object_to_yaml_str(self, obj, options={}):
         string_stream = StringIO()

--- a/tests/assets/test.yaml
+++ b/tests/assets/test.yaml
@@ -1,0 +1,2 @@
+# This is a block comment
+hello: "world"  # This is an inline comment

--- a/tests/assets/test_complex.yaml
+++ b/tests/assets/test_complex.yaml
@@ -1,0 +1,7 @@
+# This is a block comment
+hello: "world"  # This is an inline comment
+this:
+  is: "a"
+  test:
+    - "hello"
+    - "world"

--- a/tests/test_github_api.py
+++ b/tests/test_github_api.py
@@ -487,8 +487,7 @@ class TestGitHubAPI(unittest.TestCase):
         contents = {"key1": "This is a test"}
 
         contents = yaml.object_to_yaml_str(contents).encode("utf-8")
-        contents = base64.b64encode(contents)
-        contents = contents.decode("utf-8")
+        contents = base64.b64encode(contents).decode("utf-8")
 
         body = {
             "message": commit_msg,
@@ -529,8 +528,7 @@ class TestGitHubAPI(unittest.TestCase):
         contents = {"key1": "This is a test"}
 
         contents = yaml.object_to_yaml_str(contents).encode("utf-8")
-        contents = base64.b64encode(contents)
-        contents = contents.decode("utf-8")
+        contents = base64.b64encode(contents).decode("utf-8")
 
         body = {
             "message": commit_msg,

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -35,8 +35,7 @@ class TestUpdateImageTags(unittest.TestCase):
             }
         }
         expected_output = yaml.object_to_yaml_str(expected_output).encode("utf-8")
-        expected_output = base64.b64encode(expected_output)
-        expected_output = expected_output.decode("utf-8")
+        expected_output = base64.b64encode(expected_output).decode("utf-8")
 
         result = update_images.update_config()
 
@@ -81,8 +80,7 @@ class TestUpdateImageTags(unittest.TestCase):
             }
         }
         expected_output = yaml.object_to_yaml_str(expected_output).encode("utf-8")
-        expected_output = base64.b64encode(expected_output)
-        expected_output = expected_output.decode("utf-8")
+        expected_output = base64.b64encode(expected_output).decode("utf-8")
 
         result = update_images.update_config()
 
@@ -140,8 +138,7 @@ class TestUpdateImageTags(unittest.TestCase):
             }
         }
         expected_output = yaml.object_to_yaml_str(expected_output).encode("utf-8")
-        expected_output = base64.b64encode(expected_output)
-        expected_output = expected_output.decode("utf-8")
+        expected_output = base64.b64encode(expected_output).decode("utf-8")
 
         result = update_images.update_config()
 

--- a/tests/test_yaml_parser.py
+++ b/tests/test_yaml_parser.py
@@ -1,4 +1,6 @@
+import filecmp
 import unittest
+from collections import OrderedDict
 
 from tag_bot.yaml_parser import YamlParser
 
@@ -13,6 +15,61 @@ class TestYamlParser(unittest.TestCase):
         yaml = YamlParser()
         result = yaml.yaml_string_to_object("hello: world")
         self.assertEqual(result, {"hello": "world"})
+
+    def test_round_trip(self):
+        yaml = YamlParser()
+
+        with open("tests/assets/test.yaml") as stream:
+            test_yaml = yaml.yaml.load(stream)
+
+        test_yaml_str = yaml.object_to_yaml_str(test_yaml)
+        test_yaml_back_to_obj = yaml.yaml_string_to_object(test_yaml_str)
+
+        with open("tests/assets/test_output.yaml", "w") as fp:
+            yaml.yaml.dump(test_yaml_back_to_obj, fp)
+
+        expected_yaml_string = (
+            '# This is a block comment\nhello: "world"  # This is an inline comment\n'
+        )
+        expected_yaml_obj = OrderedDict()
+        expected_yaml_obj["hello"] = "world"
+
+        self.assertEqual(test_yaml_str, expected_yaml_string)
+        self.assertDictEqual(test_yaml_back_to_obj, expected_yaml_obj)
+        self.assertTrue(
+            filecmp.cmp(
+                "tests/assets/test.yaml", "tests/assets/test_output.yaml", shallow=False
+            )
+        )
+
+    def test_round_trip_complex(self):
+        yaml = YamlParser()
+
+        with open("tests/assets/test_complex.yaml") as stream:
+            test_yaml = yaml.yaml.load(stream)
+
+        test_yaml_str = yaml.object_to_yaml_str(test_yaml)
+        test_yaml_back_to_obj = yaml.yaml_string_to_object(test_yaml_str)
+
+        with open("tests/assets/test_complex_output.yaml", "w") as fp:
+            yaml.yaml.dump(test_yaml_back_to_obj, fp)
+
+        expected_yaml_string = (
+            '# This is a block comment\nhello: "world"  # This is an inline comment\nthis:\n  is: "a"\n  test:\n    - "hello"\n    - "world"\n'
+        )
+        expected_yaml_obj = OrderedDict()
+        expected_yaml_obj["hello"] = "world"
+        expected_yaml_obj["this"] = OrderedDict()
+        expected_yaml_obj["this"]["is"] = "a"
+        expected_yaml_obj["this"]["test"] = ["hello", "world"]
+
+        self.assertEqual(test_yaml_str, expected_yaml_string)
+        self.assertDictEqual(test_yaml_back_to_obj, expected_yaml_obj)
+        self.assertTrue(
+            filecmp.cmp(
+                "tests/assets/test_complex.yaml", "tests/assets/test_complex_output.yaml", shallow=False
+            )
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_yaml_parser.py
+++ b/tests/test_yaml_parser.py
@@ -1,3 +1,4 @@
+import base64
 import filecmp
 import unittest
 from collections import OrderedDict
@@ -67,6 +68,32 @@ class TestYamlParser(unittest.TestCase):
             filecmp.cmp(
                 "tests/assets/test_complex.yaml",
                 "tests/assets/test_complex_output.yaml",
+                shallow=False,
+            )
+        )
+
+    def test_round_trip_encoded(self):
+        yaml = YamlParser()
+
+        with open("tests/assets/test.yaml") as stream:
+            config = yaml.yaml.load(stream)
+
+        # Encode the config
+        encoded_config = yaml.object_to_yaml_str(config).encode("utf-8")
+        encoded_config = base64.b64encode(encoded_config).decode("utf-8")
+
+        # Reverse the encoding process
+        decoded_config = base64.b64decode(encoded_config.encode("utf-8"))
+        decoded_config = yaml.yaml_string_to_object(decoded_config.decode("utf-8"))
+
+        with open("tests/assets/test_encoded_output.yaml", "w") as fp:
+            yaml.yaml.dump(decoded_config, fp)
+
+        self.assertDictEqual(config, decoded_config)
+        self.assertTrue(
+            filecmp.cmp(
+                "tests/assets/test.yaml",
+                "tests/assets/test_encoded_output.yaml",
                 shallow=False,
             )
         )


### PR DESCRIPTION
Add some extra options to the Yaml Parser, such as preserving quotes. Add extra tests to ensure Yaml is being loaded/dumped/encoded as expected.