### PR TITLE
Update some default values for the action

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ Here is a list detailing the assumptions that the Action makes.
 | `values_paths` | A _space-delimited_ list of valid [JMESPath expressions](https://jmespath.org/) identifying the location of images in the config to check for updates. An example is: `.singleuser.profileList[0].kubespawner_override.image`. If the image name and tag are in separate fields, you can provide the path to the parent key, e.g., `.singleuser.image` will know how to parse `.singleuser.image.name` and `.singleuser.image.tag`. | :white_check_mark: | - |
 | `github_token` | A GitHub token to make requests to the API with. Requires write permissions to: create new branches, make commits, and open Pull Requests. | :x: | `${{github.token}}` |
 | `repository` | A GitHub repository containing the config for a JupyterHub deployment. | :x: | `${{github.repository}}` |
-| `base_branch` | The name of the base branch Pull Requests will be merged into. | :x: | `main` |
-| `head_branch` | The name of the branch changes will be pushed to and the Pull Request will be opened from. | :x: | `bump_image_tags-WXYZ` where `WXYZ` will be a randomly generated ascii string (to avoid clashes) |
+| `base_branch` | The name of the base branch Pull Requests will be merged into. | :x: | `${{ github.ref_name }}` |
+| `head_branch` | The name of the branch changes will be pushed to and the Pull Request will be opened from. | :x: | `bump-image-tags/{{ config path }}/WXYZ` where `WXYZ` will be a randomly generated ascii string (to avoid clashes) |
 | `labels` | A comma-separated list of labels to apply to the opened Pull Request. Labels must already exist in the repository. | :x: | `[]` |
 | `reviewers` | A comma-separated list of GitHub users (without the leading `@`) to request reviews from. | :x: | `[]` |
 | `team_reviewers` | A comma-separated list of GitHub teams, in the form `ORG_NAME/TEAM_NAME`, to request reviews from. | :x: | `[]` |

--- a/action.yaml
+++ b/action.yaml
@@ -35,14 +35,13 @@ inputs:
       The name of the base branch Pull Requests will be merged into. Defaults to
       `main`.
     required: false
-    default: "main"
+    default: ${{ github.ref_name }}
   head_branch:
     description: |
       The name of the branch changes will be pushed to and the Pull Request will
       be opened from. Defaults to `bump_image_tags-WXYZ` where `WXYZ` will be a
       randomly generated ascii string (to avoid clashes).
     required: false
-    default: "bump_image_tags"
   labels:
     description: |
       A comma-separated list of labels to apply to the opened Pull Request.

--- a/tag_bot/github_api.py
+++ b/tag_bot/github_api.py
@@ -143,7 +143,7 @@ class GitHubAPI:
                 "This Pull Request is bumping the Docker tags for the following images to the listed versions.\n\n"
                 + "\n".join(
                     [
-                        f"`{image}`: `{self.inputs.image_tags[image]['current']}` -> `{self.inputs.image_tags[image]['latest']}`"
+                        f"- `{image}`: `{self.inputs.image_tags[image]['current']}` -> `{self.inputs.image_tags[image]['latest']}`"
                         for image in self.inputs.images_to_update
                     ]
                 )

--- a/tests/test_github_api.py
+++ b/tests/test_github_api.py
@@ -98,7 +98,7 @@ class TestGitHubAPI(unittest.TestCase):
                 "This Pull Request is bumping the Docker tags for the following images to the listed versions.\n\n"
                 + "\n".join(
                     [
-                        f"`{image}`: `{main.image_tags[image]['current']}` -> `{main.image_tags[image]['latest']}`"
+                        f"- `{image}`: `{main.image_tags[image]['current']}` -> `{main.image_tags[image]['latest']}`"
                         for image in main.images_to_update
                     ]
                 )
@@ -147,7 +147,7 @@ class TestGitHubAPI(unittest.TestCase):
                 "This Pull Request is bumping the Docker tags for the following images to the listed versions.\n\n"
                 + "\n".join(
                     [
-                        f"`{image}`: `{main.image_tags[image]['current']}` -> `{main.image_tags[image]['latest']}`"
+                        f"- `{image}`: `{main.image_tags[image]['current']}` -> `{main.image_tags[image]['latest']}`"
                         for image in main.images_to_update
                     ]
                 )
@@ -220,7 +220,7 @@ class TestGitHubAPI(unittest.TestCase):
                 "This Pull Request is bumping the Docker tags for the following images to the listed versions.\n\n"
                 + "\n".join(
                     [
-                        f"`{image}`: `{main.image_tags[image]['current']}` -> `{main.image_tags[image]['latest']}`"
+                        f"- `{image}`: `{main.image_tags[image]['current']}` -> `{main.image_tags[image]['latest']}`"
                         for image in main.images_to_update
                     ]
                 )
@@ -294,7 +294,7 @@ class TestGitHubAPI(unittest.TestCase):
                 "This Pull Request is bumping the Docker tags for the following images to the listed versions.\n\n"
                 + "\n".join(
                     [
-                        f"`{image}`: `{main.image_tags[image]['current']}` -> `{main.image_tags[image]['latest']}`"
+                        f"- `{image}`: `{main.image_tags[image]['current']}` -> `{main.image_tags[image]['latest']}`"
                         for image in main.images_to_update
                     ]
                 )
@@ -372,7 +372,7 @@ class TestGitHubAPI(unittest.TestCase):
                 "This Pull Request is bumping the Docker tags for the following images to the listed versions.\n\n"
                 + "\n".join(
                     [
-                        f"`{image}`: `{main.image_tags[image]['current']}` -> `{main.image_tags[image]['latest']}`"
+                        f"- `{image}`: `{main.image_tags[image]['current']}` -> `{main.image_tags[image]['latest']}`"
                         for image in main.images_to_update
                     ]
                 )
@@ -770,7 +770,7 @@ class TestGitHubAPI(unittest.TestCase):
                 "This Pull Request is bumping the Docker tags for the following images to the listed versions.\n\n"
                 + "\n".join(
                     [
-                        f"`{image}`: `{main.image_tags[image]['current']}` -> `{main.image_tags[image]['latest']}`"
+                        f"- `{image}`: `{main.image_tags[image]['current']}` -> `{main.image_tags[image]['latest']}`"
                         for image in main.images_to_update
                     ]
                 )


### PR DESCRIPTION
- Remove a default value for `head_branch` from action.yaml - allow this to be set by the Python class
- Change default of `base_branch` to `${{ github.ref_name }}` this allows us to dynamically account for main or master branches
- PR body formatted to have bullet points