### PR TITLE
Swap jq for yq

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,12 @@
 # Use a Python slim image
 FROM python:3.10.2-slim
 
-# Install gcc
-RUN apt-get update && apt-get install --yes gcc jq
+# Install gcc and wget
+RUN apt-get update && apt-get install --yes gcc wget
+
+# Install yq
+RUN wget https://github.com/mikefarah/yq/releases/download/v4.25.2/yq_linux_amd64.tar.gz -O - | \
+  tar xz && mv yq_linux_amd64 /usr/bin/yq
 
 # Create and set the 'app' working directory
 RUN mkdir /app

--- a/tag_bot/main.py
+++ b/tag_bot/main.py
@@ -5,7 +5,7 @@ from loguru import logger
 
 from .github_api import GitHubAPI
 from .parse_image_tags import ImageTags
-from .utils import read_config_with_jq, update_config_with_jq
+from .utils import read_config_with_yq, update_config_with_yq
 from .yaml_parser import YamlParser
 
 yaml = YamlParser()
@@ -55,17 +55,17 @@ class UpdateImageTags:
         """
         logger.info("Updating JupyterHub config...")
         for image in self.images_to_update:
-            logger.info("Updating tag for image: {}", self.image_tags[image])
-            value = read_config_with_jq(self.config, self.image_tags[image]["path"])
+            logger.info("Updating tag for image: {}", image)
+            value = read_config_with_yq(self.config, self.image_tags[image]["path"])
 
             if ":" in value:
-                self.config = update_config_with_jq(
+                self.config = update_config_with_yq(
                     self.config,
                     self.image_tags[image]["path"],
                     ":".join([image, self.image_tags[image]["latest"]]),
                 )
             else:
-                self.config = update_config_with_jq(
+                self.config = update_config_with_yq(
                     self.config,
                     self.image_tags[image]["path"],
                     self.image_tags[image]["latest"],

--- a/tag_bot/parse_image_tags.py
+++ b/tag_bot/parse_image_tags.py
@@ -5,7 +5,7 @@ from itertools import compress
 from loguru import logger
 
 from .http_requests import get_request
-from .utils import read_config_with_jq
+from .utils import read_config_with_yq
 from .yaml_parser import YamlParser
 
 yaml = YamlParser()
@@ -49,7 +49,7 @@ class ImageTags:
         """Read the tags currently stored in a JupyterHub YAML config file"""
         logger.info("Fetching current image tags from config...")
         for values_path in self.inputs.values_paths:
-            value = read_config_with_jq(self.inputs.config, values_path)
+            value = read_config_with_yq(self.inputs.config, values_path)
 
             if (
                 isinstance(value, dict)

--- a/tag_bot/utils.py
+++ b/tag_bot/utils.py
@@ -1,10 +1,13 @@
-import json
 import subprocess
 import tempfile
 
+from .yaml_parser import YamlParser
 
-def update_config_with_jq(config, var_path, new_var):
-    """Run a jq command to update a variable in a JSON dictionary given the keypath
+yaml = YamlParser()
+
+
+def update_config_with_yq(config, var_path, new_var):
+    """Run a yq command to update a variable in a YAML file given the keypath
     to that variable.
 
     Args:
@@ -15,49 +18,44 @@ def update_config_with_jq(config, var_path, new_var):
     Returns:
         updated_config (dict): The updated dictionary config
     """
-    # Construct the jq command to run
-    cmd = ["jq", f'{var_path} = "{new_var}"']
+    # Construct the yq command to run
+    cmd = ["yq", f'{var_path} = "{new_var}"']
 
-    # Use a temporary file for jq to "read"
-    with tempfile.NamedTemporaryFile(mode="r+", suffix=".json") as fp:
+    # Use a temporary file for yq to "read"
+    with tempfile.NamedTemporaryFile(mode="r+", suffix=".yaml") as fp:
         # Dump the config to the temp file
-        json.dump(config, fp)
+        yaml.yaml.dump(config, fp)
         fp.flush()
 
-        # Run the jq command and capture the result
+        # Run the yq command and capture the result
         cmd.append(fp.name)
         call_output = subprocess.check_output(cmd)
 
-    # Cleaning up of the jq output, make sure it is dict format!
-    updated_config = json.loads(call_output.decode("utf-8").strip("\n"))
+    # Cleaning up of the yq output, make sure it is dict format!
+    updated_config = yaml.yaml.load(call_output.decode("utf-8").strip("\n"))
 
     return updated_config
 
 
-def read_config_with_jq(config: dict, var_path: str):
-    """Run a jq command to read a variable in a JSON dictionary given the keypath
+def read_config_with_yq(config: dict, var_path: str):
+    """Run a yq command to read a variable in a YAML file given the keypath
     to that variable.
 
     Args:
-        config (dict): The JSON dictionary config to be read
+        config (dict): The YAML config to be read
         var_path (str): The keypath to the variable that should be read
 
     Returns:
-        (dict or str): The value stored at the provided keypath. If it is not a pure
-            string, the value will be parsed by a JSON library to return the object.
+        (dict or str): The value stored at the provided keypath..
     """
-    cmd = ["jq", "-r", var_path]
+    cmd = ["yq", var_path]
 
-    with tempfile.NamedTemporaryFile(mode="r+", suffix=".json") as fp:
-        json.dump(config, fp)
+    with tempfile.NamedTemporaryFile(mode="r+", suffix=".yaml") as fp:
+        yaml.yaml.dump(config, fp)
         fp.flush()
 
         cmd.append(fp.name)
         call_output = subprocess.check_output(cmd)
 
     call_output = call_output.decode("utf-8").strip("\n")
-
-    try:
-        return json.loads(call_output)
-    except json.JSONDecodeError:
-        return call_output
+    return yaml.yaml.load(call_output)

--- a/tag_bot/yaml_parser.py
+++ b/tag_bot/yaml_parser.py
@@ -5,7 +5,7 @@ import ruamel.yaml
 
 class YamlParser:
     def __init__(self):
-        self.yaml = ruamel.yaml.YAML()
+        self.yaml = ruamel.yaml.YAML(typ="rt")
         self.yaml.indent(mapping=2, sequence=4, offset=2)
         self.yaml.allow_duplicate_keys = True
         self.yaml.explicit_start = False

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,56 +1,88 @@
-from tag_bot.utils import update_config_with_jq
+import unittest
+
+from tag_bot.utils import read_config_with_yq, update_config_with_yq
 
 
-def test_update_config_with_jq_singleuser():
-    test_config = {"singleuser": {"image": {"name": "image_name", "tag": "old_tag"}}}
-    test_image_tags = {
-        "image_name": {
-            "current": "old_tag",
-            "latest": "new_tag",
-            "path": ".singleuser.image.tag",
+class TestUtilityFunctions(unittest.TestCase):
+    def test_read_config_with_yq_singleuser(self):
+        var_path = ".singleuser.image"
+        config = {"singleuser": {"image": {"name": "my_image", "tag": "my_tag"}}}
+
+        expected_value = {"name": "my_image", "tag": "my_tag"}
+
+        value = read_config_with_yq(config, var_path)
+
+        self.assertDictEqual(value, expected_value)
+
+    def test_read_config_with_yq_profileList(self):
+        var_path = ".singleuser.profileList[0].kubespawner_override.image"
+        config = {
+            "singleuser": {
+                "profileList": [{"kubespawner_override": {"image": "owner/name:tag"}}]
+            }
         }
-    }
 
-    new_config = update_config_with_jq(
-        test_config,
-        test_image_tags["image_name"]["path"],
-        test_image_tags["image_name"]["latest"],
-    )
+        expected_value = "owner/name:tag"
 
-    expected_output = {
-        "singleuser": {"image": {"name": "image_name", "tag": "new_tag"}}
-    }
+        value = read_config_with_yq(config, var_path)
 
-    assert new_config == expected_output
+        self.assertEqual(value, expected_value)
 
-
-def test_update_config_with_jq_profileList():
-    test_config = {
-        "singleuser": {
-            "profileList": [
-                {"kubespawner_override": {"image": "image_name:old_tag"}},
-            ]
+    def test_update_config_with_yq_singleuser(self):
+        test_config = {
+            "singleuser": {"image": {"name": "image_name", "tag": "old_tag"}}
         }
-    }
-    test_image_tags = {
-        "image_name": {
-            "current": "old_tag",
-            "latest": "new_tag",
-            "path": ".singleuser.profileList[0].kubespawner_override.image",
+        test_image_tags = {
+            "image_name": {
+                "current": "old_tag",
+                "latest": "new_tag",
+                "path": ".singleuser.image.tag",
+            }
         }
-    }
 
-    new_tag = ":".join(["image_name", test_image_tags["image_name"]["latest"]])
-    new_config = update_config_with_jq(
-        test_config, test_image_tags["image_name"]["path"], new_tag
-    )
+        new_config = update_config_with_yq(
+            test_config,
+            test_image_tags["image_name"]["path"],
+            test_image_tags["image_name"]["latest"],
+        )
 
-    expected_output = {
-        "singleuser": {
-            "profileList": [
-                {"kubespawner_override": {"image": "image_name:new_tag"}},
-            ]
+        expected_output = {
+            "singleuser": {"image": {"name": "image_name", "tag": "new_tag"}}
         }
-    }
 
-    assert new_config == expected_output
+        self.assertDictEqual(new_config, expected_output)
+
+    def test_update_config_with_yq_profileList(self):
+        test_config = {
+            "singleuser": {
+                "profileList": [
+                    {"kubespawner_override": {"image": "image_name:old_tag"}},
+                ]
+            }
+        }
+        test_image_tags = {
+            "image_name": {
+                "current": "old_tag",
+                "latest": "new_tag",
+                "path": ".singleuser.profileList[0].kubespawner_override.image",
+            }
+        }
+
+        new_tag = ":".join(["image_name", test_image_tags["image_name"]["latest"]])
+        new_config = update_config_with_yq(
+            test_config, test_image_tags["image_name"]["path"], new_tag
+        )
+
+        expected_output = {
+            "singleuser": {
+                "profileList": [
+                    {"kubespawner_override": {"image": "image_name:new_tag"}},
+                ]
+            }
+        }
+
+        self.assertDictEqual(new_config, expected_output)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Finally concluded that the behaviour that was reported in #121 was due to the dumping to JSON file and updating with `jq` which lost all the roundtrip capabilities of the Yaml Parser. This PR switches to using `yq` instead (basically the same, but for yaml) which should help to preserve the Yaml

fixes #121 