### PR TITLE
Tweak how dates are sorted

### DIFF
--- a/tag_bot/parse_image_tags.py
+++ b/tag_bot/parse_image_tags.py
@@ -79,8 +79,10 @@ class ImageTags:
         url = "/".join(["https://hub.docker.com/v2/repositories", image_name, "tags"])
         resp = get_request(url, output="json")
 
+        # Sort tags by datetime last updated
         tags = sorted(resp["results"], key=lambda k: k["last_updated"])
 
+        # Find the most recent tag
         if tags[-1]["name"] == "latest":
             latest_tag = tags[-2]["name"]
         else:
@@ -98,6 +100,7 @@ class ImageTags:
         resp = get_request(url, output="json")
         tags = [resp["tags"][key] for key in resp["tags"].keys()]
 
+        # Convert the last modified datetime into a valid object
         for tag in tags:
             tag["last_modified"] = datetime.strptime(
                 tag["last_modified"], "%a, %d %b %Y %H:%M:%S %z"

--- a/tag_bot/parse_image_tags.py
+++ b/tag_bot/parse_image_tags.py
@@ -79,12 +79,12 @@ class ImageTags:
         url = "/".join(["https://hub.docker.com/v2/repositories", image_name, "tags"])
         resp = get_request(url, output="json")
 
-        tags_sorted = sorted(resp["results"], key=lambda k: k["last_updated"])
+        tags = sorted(resp["results"], key=lambda k: k["last_updated"])
 
-        if tags_sorted[-1]["name"] == "latest":
-            latest_tag = tags_sorted[-2]["name"]
+        if tags[-1]["name"] == "latest":
+            latest_tag = tags[-2]["name"]
         else:
-            latest_tag = tags_sorted[-1]["name"]
+            latest_tag = tags[-1]["name"]
 
         self.image_tags[image_name]["latest"] = latest_tag
 
@@ -103,12 +103,12 @@ class ImageTags:
                 tag["last_modified"], "%a, %d %b %Y %H:%M:%S %z"
             )
 
-        tags_sorted = sorted(tags, key=lambda k: k["last_modified"])
+        tags = sorted(tags, key=lambda k: k["last_modified"])
 
-        if tags_sorted[-1]["name"] == "latest":
-            latest_tag = tags_sorted[-2]["name"]
+        if tags[-1]["name"] == "latest":
+            latest_tag = tags[-2]["name"]
         else:
-            latest_tag = tags_sorted[-1]["name"]
+            latest_tag = tags[-1]["name"]
 
         self.image_tags[image_name]["latest"] = latest_tag
 

--- a/tag_bot/parse_image_tags.py
+++ b/tag_bot/parse_image_tags.py
@@ -102,8 +102,9 @@ class ImageTags:
 
         # Convert the last modified datetime into a valid object
         for tag in tags:
-            tag["last_modified"] = datetime.strptime(
-                tag["last_modified"], "%a, %d %b %Y %H:%M:%S %z"
+            tag["last_modified"] = datetime.strftime(
+                datetime.strptime(tag["last_modified"], "%a, %d %b %Y %H:%M:%S %z"),
+                "%Y-%m-%dT%H:%M:%S.%fZ",
             )
 
         tags = sorted(tags, key=lambda k: k["last_modified"])


### PR DESCRIPTION
- Reuse the `tags` object, preparing for optional regex filtering
- For quay.io images, conver the `last_modified` timestamp to match the format of Docker Hub so at least we can be sure they're being sorted in the same manner