### PR TITLE
[BUGFIX] Ensure container registry is stripped from image name

### DIFF
--- a/tag_bot/parse_image_tags.py
+++ b/tag_bot/parse_image_tags.py
@@ -155,12 +155,13 @@ class ImageTags:
                 )
             elif len(image.split("/")) > 2:
                 if image.split("/")[0] == "quay.io":
+                    image = "/".join(image.split("/")[1:])
                     self._get_most_recent_image_tag_quayio(
                         image, regexpr=self.image_tags[image]["regexpr"]
                     )
                 else:
                     warnings.warn(
-                        f"NotImplemented: Cannot currently retrieve image from {image.split('/')[0]}"
+                        f"NotImplemented: Cannot currently retrieve images from {image.split('/')[0]}"
                     )
                     continue
             else:


### PR DESCRIPTION
We were making API calls to `https://quay.io/api/v1/repository/quay.io/jupyterhub/repo2docker` instead of `https://quay.io/api/v1/repository/jupyterhub/repo2docker`. This PR prevents this behaviour.