### PR TITLE
Refactor how the image name is split for quay.io images

### DIFF
--- a/tag_bot/parse_image_tags.py
+++ b/tag_bot/parse_image_tags.py
@@ -110,14 +110,19 @@ class ImageTags:
 
         self.image_tags[image_name]["latest"] = latest_tag
 
-    def _get_most_recent_image_tag_quayio(self, image_name, regexpr=None):
+    def _get_most_recent_image_tag_quayio(self, full_image_name, regexpr=None):
         """For an image hosted on quay.io, look up the most recent tag
 
         Args:
-            image_name (str): The name of the image to look up tags for
+            full_image_name (str): The name of the image to look up tags for. Includes
+                the 'quay.io/' prefix.
             regexpr (str): A regular expression describing the format of tag to return.
                 Defaults to None.
         """
+        # Strip 'quay.io/' from the beginning of the image name
+        image_name = "/".join(full_image_name.split("/")[1:])
+
+        # Construct and make API call to quay.io
         url = "/".join(["https://quay.io/api/v1/repository", image_name])
         resp = get_request(url, output="json")
         tags = [resp["tags"][key] for key in resp["tags"].keys()]
@@ -140,7 +145,7 @@ class ImageTags:
         else:
             latest_tag = tags[-1]["name"]
 
-        self.image_tags[image_name]["latest"] = latest_tag
+        self.image_tags[full_image_name]["latest"] = latest_tag
 
     def _get_remote_tags(self):
         """
@@ -155,7 +160,6 @@ class ImageTags:
                 )
             elif len(image.split("/")) > 2:
                 if image.split("/")[0] == "quay.io":
-                    image = "/".join(image.split("/")[1:])
                     self._get_most_recent_image_tag_quayio(
                         image, regexpr=self.image_tags[image]["regexpr"]
                     )

--- a/tests/test_parse_image_tags.py
+++ b/tests/test_parse_image_tags.py
@@ -178,11 +178,13 @@ class TestImageTags(unittest.TestCase):
             [{"values_path": ".singleuser.image"}],
         )
         image_parser = ImageTags(main, "octocat/octocat", "main")
-        image_parser.image_tags = {"image_owner/image_name": {"current": "image_tag"}}
-        image = "image_owner/image_name"
+        image_parser.image_tags = {
+            "quay.io/image_owner/image_name": {"current": "image_tag"}
+        }
+        image = "quay.io/image_owner/image_name"
 
         expected_image_tags = {
-            "image_owner/image_name": {
+            "quay.io/image_owner/image_name": {
                 "current": "image_tag",
                 "latest": "new_image_tag",
             }
@@ -213,7 +215,12 @@ class TestImageTags(unittest.TestCase):
 
             self.assertEqual(mock.call_count, 1)
             mock.assert_called_with(
-                "/".join(["https://quay.io/api/v1/repository", image]),
+                "/".join(
+                    [
+                        "https://quay.io/api/v1/repository",
+                        "/".join(image.split("/")[1:]),
+                    ]
+                ),
                 output="json",
             )
             self.assertDictEqual(image_parser.image_tags, expected_image_tags)
@@ -231,11 +238,13 @@ class TestImageTags(unittest.TestCase):
             ],
         )
         image_parser = ImageTags(main, "octocat/octocat", "main")
-        image_parser.image_tags = {"image_owner/image_name": {"current": "image_tag"}}
-        image = "image_owner/image_name"
+        image_parser.image_tags = {
+            "quay.io/image_owner/image_name": {"current": "image_tag"}
+        }
+        image = "quay.io/image_owner/image_name"
 
         expected_image_tags = {
-            "image_owner/image_name": {
+            "quay.io/image_owner/image_name": {
                 "current": "image_tag",
                 "latest": "2022.06.09",
             }
@@ -268,7 +277,12 @@ class TestImageTags(unittest.TestCase):
 
             self.assertEqual(mock.call_count, 1)
             mock.assert_called_with(
-                "/".join(["https://quay.io/api/v1/repository", image]),
+                "/".join(
+                    [
+                        "https://quay.io/api/v1/repository",
+                        "/".join(image.split("/")[1:]),
+                    ]
+                ),
                 output="json",
             )
             self.assertDictEqual(image_parser.image_tags, expected_image_tags)


### PR DESCRIPTION
Continuation of #135 