### PR TITLE
Move around fork/branch creation

### DIFF
--- a/tag_bot/main.py
+++ b/tag_bot/main.py
@@ -86,9 +86,8 @@ class UpdateImageTags:
         if self.push_to_users_fork is not None:
             github.check_fork_exists()
 
-        branch = self.head_branch if github.pr_exists else self.base_branch
-
         url = github.fork_api_url if github.fork_exists else github.api_url
+        branch = self.head_branch if github.pr_exists else self.base_branch
 
         image_parser = ImageTags(self, url, branch)
         image_parser.get_image_tags()


### PR DESCRIPTION
Runs of the action were creating a new branch even if there was nothing to commit and open a PR for (including when the dry-run flag was set). This PR moves around when forks and branches are created so they're only called when there is a PR to be opened (and dry-run is not set).