### PR TITLE
Pass the github token to the request to grab gh packages

### DIFF
--- a/tag_bot/parse_image_tags.py
+++ b/tag_bot/parse_image_tags.py
@@ -162,7 +162,7 @@ class ImageTags:
                 "versions",
             ]
         )
-        tags = get_request(url, output="json")
+        tags = get_request(url, headers=self.inputs.headers, output="json")
 
         # Convert the last updated metadata into a valid datetime object
         for tag in tags:

--- a/tests/test_parse_image_tags.py
+++ b/tests/test_parse_image_tags.py
@@ -331,7 +331,10 @@ class TestImageTags(unittest.TestCase):
             self.assertEqual(mock.call_count, 1)
             mock.assert_called_with(
                 f"https://api.github.com/orgs/{org}/packages/container/{img_name}/versions",
-                headers={'Accept': 'application/vnd.github.v3+json', 'Authorization': 'token ThIs_Is_A_t0k3n'},
+                headers={
+                    "Accept": "application/vnd.github.v3+json",
+                    "Authorization": "token ThIs_Is_A_t0k3n",
+                },
                 output="json",
             )
 
@@ -389,7 +392,10 @@ class TestImageTags(unittest.TestCase):
             _, org, img_name = image.split("/")
             mock.assert_called_with(
                 f"https://api.github.com/orgs/{org}/packages/container/{img_name}/versions",
-                headers={'Accept': 'application/vnd.github.v3+json', 'Authorization': 'token ThIs_Is_A_t0k3n'},
+                headers={
+                    "Accept": "application/vnd.github.v3+json",
+                    "Authorization": "token ThIs_Is_A_t0k3n",
+                },
                 output="json",
             )
             self.assertDictEqual(image_parser.image_tags, expected_image_tags)

--- a/tests/test_parse_image_tags.py
+++ b/tests/test_parse_image_tags.py
@@ -331,6 +331,7 @@ class TestImageTags(unittest.TestCase):
             self.assertEqual(mock.call_count, 1)
             mock.assert_called_with(
                 f"https://api.github.com/orgs/{org}/packages/container/{img_name}/versions",
+                headers={'Accept': 'application/vnd.github.v3+json', 'Authorization': 'token ThIs_Is_A_t0k3n'},
                 output="json",
             )
 
@@ -388,6 +389,7 @@ class TestImageTags(unittest.TestCase):
             _, org, img_name = image.split("/")
             mock.assert_called_with(
                 f"https://api.github.com/orgs/{org}/packages/container/{img_name}/versions",
+                headers={'Accept': 'application/vnd.github.v3+json', 'Authorization': 'token ThIs_Is_A_t0k3n'},
                 output="json",
             )
             self.assertDictEqual(image_parser.image_tags, expected_image_tags)


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request!

Don't worry, these HTML comments won't render in your issue.
Feel free to delete them once you've read them :) -->

### Summary
<!-- Please describe the purpose of this PR.
Is it fixing a bug or adding a feature?

Please reference relevant issue numbers with action words to close them if relevant. -->

Based on https://github.com/2i2c-org/infrastructure/runs/7687598884?check_suite_focus=true#step:3:1 and the GitHub docs, I believe we need to pass the token to the requests that grabs the packages.


fix #<!-- Enter relevant issue number here -->

### What's changed?
<!-- You can use this section to go into more detail about what's changed.
We recommend using bullet points. -->

- <!-- Enter details of changed filename here -->
-

### What should a reviewer concentrate their feedback on?
<!-- You can use this section to request specific feedback.
We recommend using check boxes. -->

- [ ] <!-- Enter request for specific feedback here -->
- [ ] Everything looks ok?
