### PR TITLE
Get the tag name from the metadata field

### DIFF
--- a/tag_bot/parse_image_tags.py
+++ b/tag_bot/parse_image_tags.py
@@ -171,16 +171,21 @@ class ImageTags:
         # Sort tags by datetime last updated
         tags = sorted(tags, key=lambda k: k["updated_at"])
 
+        # Make sure we're looking only at versions that have pushed tags
+        tags = [tag for tag in tags if tag["metadata"]["container"]["tags"] is not None]
+
         if regexpr is not None:
             # Filter the names of the tags based on a regular expression
             regexpr = re.compile(regexpr)
-            tags = [tag for tag in tags if regexpr.match(tag["name"]) is not None]
+            tags = [tag for tag in tags if regexpr.match(tag["metadata"]["container"]["tags"][0]) is not None]
 
         # Find the most recent tag
-        if tags[-1]["name"] == "latest":
-            latest_tag = tags[-2]["name"]
-        else:
-            latest_tag = tags[-1]["name"]
+        latest_tag = None
+        if tags:
+            if tags[-1]["metadata"]["container"]["tags"][0] == "latest":
+                latest_tag = tags[-2]["metadata"]["container"]["tags"][0]
+            else:
+                latest_tag = tags[-1]["metadata"]["container"]["tags"][0]
 
         self.image_tags[image_name]["latest"] = latest_tag
 

--- a/tag_bot/parse_image_tags.py
+++ b/tag_bot/parse_image_tags.py
@@ -177,7 +177,11 @@ class ImageTags:
         if regexpr is not None:
             # Filter the names of the tags based on a regular expression
             regexpr = re.compile(regexpr)
-            tags = [tag for tag in tags if regexpr.match(tag["metadata"]["container"]["tags"][0]) is not None]
+            tags = [
+                tag
+                for tag in tags
+                if regexpr.match(tag["metadata"]["container"]["tags"][0]) is not None
+            ]
 
         # Find the most recent tag
         latest_tag = None

--- a/tests/test_parse_image_tags.py
+++ b/tests/test_parse_image_tags.py
@@ -314,37 +314,25 @@ class TestImageTags(unittest.TestCase):
                     "updated_at": "2022-10-29T15:42:12Z",
                     "name": "sha256:bd084421f3b0b77b57d81e616f7bba155d988d609575d4e97bd32eebbbfbb7c3",
                     "metadata": {
-                      "package_type": "container",
-                      "container": {
-                        "tags": [
-                          "latest"
-                        ]
-                      }
-                    }
+                        "package_type": "container",
+                        "container": {"tags": ["latest"]},
+                    },
                 },
                 {
                     "updated_at": "2022-10-29T15:42:12Z",
                     "name": "sha256:bd084421f3b0b77b57dsdfgdffgdfba155d988d609575d4e97bd32eebbbfbb7c3",
                     "metadata": {
-                      "package_type": "container",
-                      "container": {
-                        "tags": [
-                          "new_image_tag"
-                        ]
-                      }
-                    }
+                        "package_type": "container",
+                        "container": {"tags": ["new_image_tag"]},
+                    },
                 },
                 {
                     "updated_at": "2019-10-29T12:42:12Z",
                     "name": "sha256:fdgbfghfghfgfgfb57dsdfgdffgdfba155d988d609575d4e97bd32eebbbfbb7c3",
                     "metadata": {
-                      "package_type": "container",
-                      "container": {
-                        "tags": [
-                          "some_other_tag"
-                        ]
-                      }
-                    }
+                        "package_type": "container",
+                        "container": {"tags": ["some_other_tag"]},
+                    },
                 },
             ],
         )
@@ -396,37 +384,25 @@ class TestImageTags(unittest.TestCase):
                     "updated_at": "2022-10-29T15:42:12Z",
                     "name": "sha256:bd084421f3b0b77b57d81e616f7bba155d988d609575d4e97bd32eebbbfbb7c3",
                     "metadata": {
-                      "package_type": "container",
-                      "container": {
-                        "tags": [
-                          "latest"
-                        ]
-                      }
-                    }
+                        "package_type": "container",
+                        "container": {"tags": ["latest"]},
+                    },
                 },
                 {
                     "updated_at": "2022-10-29T15:42:12Z",
                     "name": "sha256:bd084421f3b0b77b57dsdfgdffgdfba155d988d609575d4e97bd32eebbbfbb7c3",
                     "metadata": {
-                      "package_type": "container",
-                      "container": {
-                        "tags": [
-                          "2022.06.09"
-                        ]
-                      }
-                    }
+                        "package_type": "container",
+                        "container": {"tags": ["2022.06.09"]},
+                    },
                 },
                 {
                     "updated_at": "2019-10-29T12:42:12Z",
                     "name": "sha256:fdgbfghfghfgfgfb57dsdfgdffgdfba155d988d609575d4e97bd32eebbbfbb7c3",
                     "metadata": {
-                      "package_type": "container",
-                      "container": {
-                        "tags": [
-                          "2019-10-29T12:42:12Z"
-                        ]
-                      }
-                    }
+                        "package_type": "container",
+                        "container": {"tags": ["2019-10-29T12:42:12Z"]},
+                    },
                 },
             ],
         )

--- a/tests/test_parse_image_tags.py
+++ b/tests/test_parse_image_tags.py
@@ -312,15 +312,39 @@ class TestImageTags(unittest.TestCase):
             return_value=[
                 {
                     "updated_at": "2022-10-29T15:42:12Z",
-                    "name": "latest",
+                    "name": "sha256:bd084421f3b0b77b57d81e616f7bba155d988d609575d4e97bd32eebbbfbb7c3",
+                    "metadata": {
+                      "package_type": "container",
+                      "container": {
+                        "tags": [
+                          "latest"
+                        ]
+                      }
+                    }
                 },
                 {
                     "updated_at": "2022-10-29T15:42:12Z",
-                    "name": "new_image_tag",
+                    "name": "sha256:bd084421f3b0b77b57dsdfgdffgdfba155d988d609575d4e97bd32eebbbfbb7c3",
+                    "metadata": {
+                      "package_type": "container",
+                      "container": {
+                        "tags": [
+                          "new_image_tag"
+                        ]
+                      }
+                    }
                 },
                 {
                     "updated_at": "2019-10-29T12:42:12Z",
-                    "name": "some_other_tag",
+                    "name": "sha256:fdgbfghfghfgfgfb57dsdfgdffgdfba155d988d609575d4e97bd32eebbbfbb7c3",
+                    "metadata": {
+                      "package_type": "container",
+                      "container": {
+                        "tags": [
+                          "some_other_tag"
+                        ]
+                      }
+                    }
                 },
             ],
         )
@@ -370,15 +394,39 @@ class TestImageTags(unittest.TestCase):
             return_value=[
                 {
                     "updated_at": "2022-10-29T15:42:12Z",
-                    "name": "latest",
+                    "name": "sha256:bd084421f3b0b77b57d81e616f7bba155d988d609575d4e97bd32eebbbfbb7c3",
+                    "metadata": {
+                      "package_type": "container",
+                      "container": {
+                        "tags": [
+                          "latest"
+                        ]
+                      }
+                    }
                 },
                 {
                     "updated_at": "2022-10-29T15:42:12Z",
-                    "name": "2022.06.09",
+                    "name": "sha256:bd084421f3b0b77b57dsdfgdffgdfba155d988d609575d4e97bd32eebbbfbb7c3",
+                    "metadata": {
+                      "package_type": "container",
+                      "container": {
+                        "tags": [
+                          "2022.06.09"
+                        ]
+                      }
+                    }
                 },
                 {
                     "updated_at": "2019-10-29T12:42:12Z",
-                    "name": "some_other_tag",
+                    "name": "sha256:fdgbfghfghfgfgfb57dsdfgdffgdfba155d988d609575d4e97bd32eebbbfbb7c3",
+                    "metadata": {
+                      "package_type": "container",
+                      "container": {
+                        "tags": [
+                          "2019-10-29T12:42:12Z"
+                        ]
+                      }
+                    }
                 },
             ],
         )


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request!

Don't worry, these HTML comments won't render in your issue.
Feel free to delete them once you've read them :) -->

### Summary
<!-- Please describe the purpose of this PR.
Is it fixing a bug or adding a feature?

Please reference relevant issue numbers with action words to close them if relevant. -->

The tag name is actually stored in `.metadata.contaner.tags` and the `.name` field is actually the full sha of the commit.

Ref: https://github.com/2i2c-org/infrastructure/pull/1603

fix #<!-- Enter relevant issue number here -->

### What's changed?
<!-- You can use this section to go into more detail about what's changed.
We recommend using bullet points. -->

- <!-- Enter details of changed filename here -->
-

### What should a reviewer concentrate their feedback on?
<!-- You can use this section to request specific feedback.
We recommend using check boxes. -->

- [ ] <!-- Enter request for specific feedback here -->
- [ ] Everything looks ok?
